### PR TITLE
Parse IncidentID from betteruptime URLs

### DIFF
--- a/cmd/incidents/acknowledge.go
+++ b/cmd/incidents/acknowledge.go
@@ -28,7 +28,7 @@ var acknowledgeCmd = &cobra.Command{
 				return err
 			}
 			for _, incident := range activeIncidents {
-				fmt.Printf("acknowleding incident %s (%s)\n", incident.Attributes.Name, incident.Id)
+				fmt.Printf("acknowledging incident %s (%s)\n", incident.Attributes.Name, incident.Id)
 				err := client.AcknowledgeIncident(cmd.Context(), incident.Id, acknowledgedBy)
 				if err != nil {
 					return err
@@ -37,8 +37,13 @@ var acknowledgeCmd = &cobra.Command{
 			return nil
 		}
 
-		for _, incidentID := range args {
-			err := client.AcknowledgeIncident(cmd.Context(), incidentID, acknowledgedBy)
+		for _, possibleID := range args {
+			incidentID, err := betteruptime.IncidentIDFromURL(possibleID)
+			if err != nil {
+				return err
+			}
+
+			err = client.AcknowledgeIncident(cmd.Context(), incidentID, acknowledgedBy)
 			if err != nil {
 				return err
 			}

--- a/cmd/incidents/delete.go
+++ b/cmd/incidents/delete.go
@@ -15,8 +15,13 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := betteruptime.NewClient()
 
-		for _, incidentID := range args {
-			err := client.DeleteIncident(incidentID)
+		for _, possibleID := range args {
+			incidentID, err := betteruptime.IncidentIDFromURL(possibleID)
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteIncident(incidentID)
 			if err != nil {
 				return err
 			}

--- a/cmd/incidents/resolve.go
+++ b/cmd/incidents/resolve.go
@@ -1,0 +1,31 @@
+package incidents
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/uptime-cli/uptimectl/pkg/betteruptime"
+)
+
+// deleteCmd represents the get command
+var resolveCmd = &cobra.Command{
+	Use:     "resolve",
+	Short:   "Resolve an incident",
+	Aliases: []string{"res"},
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := betteruptime.NewClient()
+
+		for _, incidentID := range args {
+			err := client.ResolveIncident(incidentID, acknowledgedBy)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	IncidentsCmd.AddCommand(resolveCmd)
+	resolveCmd.Flags().StringVar(&acknowledgedBy, "acknowledged-by", "uptimectl", "User e-mail or a custom identifier of the entity that acknowledged the incident")
+}

--- a/cmd/incidents/resolve.go
+++ b/cmd/incidents/resolve.go
@@ -19,8 +19,13 @@ var resolveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := betteruptime.NewClient()
 
-		for _, incidentID := range args {
-			err := client.ResolveIncident(incidentID, resolvedBy)
+		for _, possibleID := range args {
+			incidentID, err := betteruptime.IncidentIDFromURL(possibleID)
+			if err != nil {
+				return err
+			}
+
+			err = client.ResolveIncident(incidentID, resolvedBy)
 			if err != nil {
 				return err
 			}

--- a/cmd/incidents/resolve.go
+++ b/cmd/incidents/resolve.go
@@ -6,7 +6,11 @@ import (
 	"github.com/uptime-cli/uptimectl/pkg/betteruptime"
 )
 
-// deleteCmd represents the get command
+var (
+	resolvedBy string
+)
+
+// resolveCmd represents the get command
 var resolveCmd = &cobra.Command{
 	Use:     "resolve",
 	Short:   "Resolve an incident",
@@ -16,7 +20,7 @@ var resolveCmd = &cobra.Command{
 		client := betteruptime.NewClient()
 
 		for _, incidentID := range args {
-			err := client.ResolveIncident(incidentID, acknowledgedBy)
+			err := client.ResolveIncident(incidentID, resolvedBy)
 			if err != nil {
 				return err
 			}
@@ -27,5 +31,5 @@ var resolveCmd = &cobra.Command{
 
 func init() {
 	IncidentsCmd.AddCommand(resolveCmd)
-	resolveCmd.Flags().StringVar(&acknowledgedBy, "acknowledged-by", "uptimectl", "User e-mail or a custom identifier of the entity that acknowledged the incident")
+	resolveCmd.Flags().StringVar(&resolvedBy, "resolved-by", "uptimectl", "User e-mail or a custom identifier of the entity that resolved the incident")
 }

--- a/cmd/statuspages/resources.go
+++ b/cmd/statuspages/resources.go
@@ -42,7 +42,7 @@ var getResourcesCmd = &cobra.Command{
 		if noHeader {
 			table.Print(nil, body)
 		} else {
-			table.Print([]string{"ID", "Name", "Show History", "Explaination", "Type", "Widget"}, body)
+			table.Print([]string{"ID", "Name", "Show History", "Explanation", "Type", "Widget"}, body)
 		}
 		return nil
 	},

--- a/docs/references/uptimectl.md
+++ b/docs/references/uptimectl.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl"
 displayName: "uptimectl"
 slug: uptimectl
 url: /docs/references/uptimectl/uptimectl/
 description: ""
 lead: ""
-weight: 731
+weight: 730
 toc: true
 ---
 ## uptimectl

--- a/docs/references/uptimectl_auth.md
+++ b/docs/references/uptimectl_auth.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl auth"
 displayName: "auth"
 slug: uptimectl_auth

--- a/docs/references/uptimectl_auth_login.md
+++ b/docs/references/uptimectl_auth_login.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl auth login"
 displayName: "auth login"
 slug: uptimectl_auth_login

--- a/docs/references/uptimectl_auth_logout.md
+++ b/docs/references/uptimectl_auth_logout.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl auth logout"
 displayName: "auth logout"
 slug: uptimectl_auth_logout

--- a/docs/references/uptimectl_config.md
+++ b/docs/references/uptimectl_config.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config"
 displayName: "config"
 slug: uptimectl_config

--- a/docs/references/uptimectl_config_current-context.md
+++ b/docs/references/uptimectl_config_current-context.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config current-context"
 displayName: "config current-context"
 slug: uptimectl_config_current-context

--- a/docs/references/uptimectl_config_get-contexts.md
+++ b/docs/references/uptimectl_config_get-contexts.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config get-contexts"
 displayName: "config get-contexts"
 slug: uptimectl_config_get-contexts

--- a/docs/references/uptimectl_config_use-context.md
+++ b/docs/references/uptimectl_config_use-context.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config use-context"
 displayName: "config use-context"
 slug: uptimectl_config_use-context

--- a/docs/references/uptimectl_config_use-organisation.md
+++ b/docs/references/uptimectl_config_use-organisation.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config use-organisation"
 displayName: "config use-organisation"
 slug: uptimectl_config_use-organisation

--- a/docs/references/uptimectl_config_view.md
+++ b/docs/references/uptimectl_config_view.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl config view"
 displayName: "config view"
 slug: uptimectl_config_view

--- a/docs/references/uptimectl_incident.md
+++ b/docs/references/uptimectl_incident.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl incident"
 displayName: "incident"
 slug: uptimectl_incident
 url: /docs/references/uptimectl/uptimectl_incident/
 description: ""
 lead: ""
-weight: 747
+weight: 746
 toc: true
 ---
 ## uptimectl incident
@@ -25,4 +25,5 @@ Manage incidents
 * [uptimectl incident acknowledge](/docs/references/uptimectl/uptimectl_incident_acknowledge/)	 - acknowledge an incident
 * [uptimectl incident delete](/docs/references/uptimectl/uptimectl_incident_delete/)	 - Delete an incident
 * [uptimectl incident list](/docs/references/uptimectl/uptimectl_incident_list/)	 - Get a list of incidents
+* [uptimectl incident resolve](/docs/references/uptimectl/uptimectl_incident_resolve/)	 - Resolve an incident
 

--- a/docs/references/uptimectl_incident_acknowledge.md
+++ b/docs/references/uptimectl_incident_acknowledge.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl incident acknowledge"
 displayName: "incident acknowledge"
 slug: uptimectl_incident_acknowledge

--- a/docs/references/uptimectl_incident_delete.md
+++ b/docs/references/uptimectl_incident_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl incident delete"
 displayName: "incident delete"
 slug: uptimectl_incident_delete

--- a/docs/references/uptimectl_incident_list.md
+++ b/docs/references/uptimectl_incident_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl incident list"
 displayName: "incident list"
 slug: uptimectl_incident_list

--- a/docs/references/uptimectl_incident_resolve.md
+++ b/docs/references/uptimectl_incident_resolve.md
@@ -1,0 +1,30 @@
+---
+date: 2023-11-17T13:00:50-05:00
+title: "uptimectl incident resolve"
+displayName: "incident resolve"
+slug: uptimectl_incident_resolve
+url: /docs/references/uptimectl/uptimectl_incident_resolve/
+description: ""
+lead: ""
+weight: 747
+toc: true
+---
+## uptimectl incident resolve
+
+Resolve an incident
+
+```
+uptimectl incident resolve [flags]
+```
+
+### Options
+
+```
+      --acknowledged-by string   User e-mail or a custom identifier of the entity that acknowledged the incident (default "uptimectl")
+  -h, --help                     help for resolve
+```
+
+### SEE ALSO
+
+* [uptimectl incident](/docs/references/uptimectl/uptimectl_incident/)	 - Manage incidents
+

--- a/docs/references/uptimectl_monitor-groups.md
+++ b/docs/references/uptimectl_monitor-groups.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitor-groups"
 displayName: "monitor-groups"
 slug: uptimectl_monitor-groups
 url: /docs/references/uptimectl/uptimectl_monitor-groups/
 description: ""
 lead: ""
-weight: 743
+weight: 742
 toc: true
 ---
 ## uptimectl monitor-groups

--- a/docs/references/uptimectl_monitor-groups_create.md
+++ b/docs/references/uptimectl_monitor-groups_create.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitor-groups create"
 displayName: "monitor-groups create"
 slug: uptimectl_monitor-groups_create
 url: /docs/references/uptimectl/uptimectl_monitor-groups_create/
 description: ""
 lead: ""
-weight: 746
+weight: 745
 toc: true
 ---
 ## uptimectl monitor-groups create

--- a/docs/references/uptimectl_monitor-groups_delete.md
+++ b/docs/references/uptimectl_monitor-groups_delete.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitor-groups delete"
 displayName: "monitor-groups delete"
 slug: uptimectl_monitor-groups_delete
 url: /docs/references/uptimectl/uptimectl_monitor-groups_delete/
 description: ""
 lead: ""
-weight: 745
+weight: 744
 toc: true
 ---
 ## uptimectl monitor-groups delete

--- a/docs/references/uptimectl_monitor-groups_get.md
+++ b/docs/references/uptimectl_monitor-groups_get.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitor-groups get"
 displayName: "monitor-groups get"
 slug: uptimectl_monitor-groups_get
 url: /docs/references/uptimectl/uptimectl_monitor-groups_get/
 description: ""
 lead: ""
-weight: 744
+weight: 743
 toc: true
 ---
 ## uptimectl monitor-groups get

--- a/docs/references/uptimectl_monitors.md
+++ b/docs/references/uptimectl_monitors.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitors"
 displayName: "monitors"
 slug: uptimectl_monitors
 url: /docs/references/uptimectl/uptimectl_monitors/
 description: ""
 lead: ""
-weight: 739
+weight: 738
 toc: true
 ---
 ## uptimectl monitors

--- a/docs/references/uptimectl_monitors_create.md
+++ b/docs/references/uptimectl_monitors_create.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitors create"
 displayName: "monitors create"
 slug: uptimectl_monitors_create
 url: /docs/references/uptimectl/uptimectl_monitors_create/
 description: ""
 lead: ""
-weight: 742
+weight: 741
 toc: true
 ---
 ## uptimectl monitors create

--- a/docs/references/uptimectl_monitors_delete.md
+++ b/docs/references/uptimectl_monitors_delete.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitors delete"
 displayName: "monitors delete"
 slug: uptimectl_monitors_delete
 url: /docs/references/uptimectl/uptimectl_monitors_delete/
 description: ""
 lead: ""
-weight: 741
+weight: 740
 toc: true
 ---
 ## uptimectl monitors delete

--- a/docs/references/uptimectl_monitors_get.md
+++ b/docs/references/uptimectl_monitors_get.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl monitors get"
 displayName: "monitors get"
 slug: uptimectl_monitors_get
 url: /docs/references/uptimectl/uptimectl_monitors_get/
 description: ""
 lead: ""
-weight: 740
+weight: 739
 toc: true
 ---
 ## uptimectl monitors get

--- a/docs/references/uptimectl_on-call.md
+++ b/docs/references/uptimectl_on-call.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl on-call"
 displayName: "on-call"
 slug: uptimectl_on-call
 url: /docs/references/uptimectl/uptimectl_on-call/
 description: ""
 lead: ""
-weight: 738
+weight: 737
 toc: true
 ---
 ## uptimectl on-call

--- a/docs/references/uptimectl_status-pages.md
+++ b/docs/references/uptimectl_status-pages.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl status-pages"
 displayName: "status-pages"
 slug: uptimectl_status-pages
 url: /docs/references/uptimectl/uptimectl_status-pages/
 description: ""
 lead: ""
-weight: 733
+weight: 732
 toc: true
 ---
 ## uptimectl status-pages

--- a/docs/references/uptimectl_status-pages_create.md
+++ b/docs/references/uptimectl_status-pages_create.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl status-pages create"
 displayName: "status-pages create"
 slug: uptimectl_status-pages_create
 url: /docs/references/uptimectl/uptimectl_status-pages_create/
 description: ""
 lead: ""
-weight: 737
+weight: 736
 toc: true
 ---
 ## uptimectl status-pages create

--- a/docs/references/uptimectl_status-pages_delete.md
+++ b/docs/references/uptimectl_status-pages_delete.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl status-pages delete"
 displayName: "status-pages delete"
 slug: uptimectl_status-pages_delete
 url: /docs/references/uptimectl/uptimectl_status-pages_delete/
 description: ""
 lead: ""
-weight: 736
+weight: 735
 toc: true
 ---
 ## uptimectl status-pages delete

--- a/docs/references/uptimectl_status-pages_get.md
+++ b/docs/references/uptimectl_status-pages_get.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl status-pages get"
 displayName: "status-pages get"
 slug: uptimectl_status-pages_get
 url: /docs/references/uptimectl/uptimectl_status-pages_get/
 description: ""
 lead: ""
-weight: 735
+weight: 734
 toc: true
 ---
 ## uptimectl status-pages get

--- a/docs/references/uptimectl_status-pages_resources.md
+++ b/docs/references/uptimectl_status-pages_resources.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl status-pages resources"
 displayName: "status-pages resources"
 slug: uptimectl_status-pages_resources
 url: /docs/references/uptimectl/uptimectl_status-pages_resources/
 description: ""
 lead: ""
-weight: 734
+weight: 733
 toc: true
 ---
 ## uptimectl status-pages resources

--- a/docs/references/uptimectl_version.md
+++ b/docs/references/uptimectl_version.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-15T01:47:17+01:00
+date: 2023-11-17T13:00:50-05:00
 title: "uptimectl version"
 displayName: "version"
 slug: uptimectl_version
 url: /docs/references/uptimectl/uptimectl_version/
 description: ""
 lead: ""
-weight: 732
+weight: 731
 toc: true
 ---
 ## uptimectl version

--- a/pkg/betteruptime/incidents.go
+++ b/pkg/betteruptime/incidents.go
@@ -95,12 +95,12 @@ func (c *client) AcknowledgeIncident(ctx context.Context, incidentID, acknowledg
 	return nil
 }
 
-func (c *client) ResolveIncident(incidentID string, acknowledgedBy string) error {
+func (c *client) ResolveIncident(incidentID string, resolvedBy string) error {
 	endpoint := fmt.Sprintf("%s/%s/%s/resolve", contextmanager.APIEndpoint(), incidentsEndpoint, incidentID)
 
 	resp, err := c.rest.R().
-		SetBody(Acknowledge{
-			AcknowledgedBy: acknowledgedBy,
+		SetBody(Resolve{
+			ResolvedBy: resolvedBy,
 		}).
 		Post(endpoint)
 	if err != nil {
@@ -114,6 +114,10 @@ func (c *client) ResolveIncident(incidentID string, acknowledgedBy string) error
 		return fmt.Errorf("incorrect status response from api")
 	}
 	return nil
+}
+
+type Resolve struct {
+	ResolvedBy string `json:"resolved_by"`
 }
 
 type Acknowledge struct {

--- a/pkg/betteruptime/incidents.go
+++ b/pkg/betteruptime/incidents.go
@@ -95,6 +95,27 @@ func (c *client) AcknowledgeIncident(ctx context.Context, incidentID, acknowledg
 	return nil
 }
 
+func (c *client) ResolveIncident(incidentID string, acknowledgedBy string) error {
+	endpoint := fmt.Sprintf("%s/%s/%s/resolve", contextmanager.APIEndpoint(), incidentsEndpoint, incidentID)
+
+	resp, err := c.rest.R().
+		SetBody(Acknowledge{
+			AcknowledgedBy: acknowledgedBy,
+		}).
+		Post(endpoint)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() == http.StatusNotFound {
+		return fmt.Errorf("incident not found")
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("incorrect status response from api")
+	}
+	return nil
+}
+
 type Acknowledge struct {
 	AcknowledgedBy string `json:"acknowledged_by"`
 }


### PR DESCRIPTION
Ignore the first 3 commits to this PR. They're part of #1 , I will rebase this PR when #1 is merged.

- Maintains old behaviour where you can directly pass an incidentID
- if a URL is passed, extracts the ID from it
- Also fixed two typos