### PR TITLE
rename the PR workflow to build

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  build-push:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Rename the PR workflow to build, since it does not push any artifacts.
