### PR TITLE
add monitor pause and unpause commands

### DIFF
--- a/cmd/monitors/examples/pause.txt
+++ b/cmd/monitors/examples/pause.txt
@@ -1,0 +1,5 @@
+# Pause a monitor
+uptimectl monitors pause 1234567
+
+# Pause multiple monitors
+uptimectl monitors pause 1234567 2345678 3456789

--- a/cmd/monitors/examples/unpause.txt
+++ b/cmd/monitors/examples/unpause.txt
@@ -1,0 +1,5 @@
+# Unpause a monitor
+uptimectl monitors unpause 1234567
+
+# Unpause multiple monitors
+uptimectl monitors unpause 1234567 2345678 3456789

--- a/cmd/monitors/pause.go
+++ b/cmd/monitors/pause.go
@@ -1,0 +1,34 @@
+package monitors
+
+import (
+	_ "embed"
+
+	"github.com/spf13/cobra"
+	"github.com/uptime-cli/uptimectl/pkg/betteruptime"
+)
+
+//go:embed examples/pause.txt
+var pauseExamples string
+
+// pauseCmd represents the pause command
+var pauseCmd = &cobra.Command{
+	Use:     "pause",
+	Short:   "Pause monitors by ID",
+	Args:    cobra.MinimumNArgs(1),
+	Example: pauseExamples,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := betteruptime.NewClient()
+
+		for _, monitor := range args {
+			err := client.PauseMonitor(monitor)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	MonitorsCmd.AddCommand(pauseCmd)
+}

--- a/cmd/monitors/unpause.go
+++ b/cmd/monitors/unpause.go
@@ -1,0 +1,34 @@
+package monitors
+
+import (
+	_ "embed"
+
+	"github.com/spf13/cobra"
+	"github.com/uptime-cli/uptimectl/pkg/betteruptime"
+)
+
+//go:embed examples/unpause.txt
+var unPauseExamples string
+
+// unPauseCmd represents the unpause command
+var unPauseCmd = &cobra.Command{
+	Use:     "unpause",
+	Short:   "Unpause monitors by ID",
+	Args:    cobra.MinimumNArgs(1),
+	Example: unPauseExamples,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := betteruptime.NewClient()
+
+		for _, monitor := range args {
+			err := client.UnpauseMonitor(monitor)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	MonitorsCmd.AddCommand(unPauseCmd)
+}

--- a/docs/references/uptimectl.md
+++ b/docs/references/uptimectl.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl"
 displayName: "uptimectl"
 slug: uptimectl
 url: /docs/references/uptimectl/uptimectl/
 description: ""
 lead: ""
-weight: 730
+weight: 728
 toc: true
 ---
 ## uptimectl

--- a/docs/references/uptimectl_auth.md
+++ b/docs/references/uptimectl_auth.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl auth"
 displayName: "auth"
 slug: uptimectl_auth

--- a/docs/references/uptimectl_auth_login.md
+++ b/docs/references/uptimectl_auth_login.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl auth login"
 displayName: "auth login"
 slug: uptimectl_auth_login

--- a/docs/references/uptimectl_auth_logout.md
+++ b/docs/references/uptimectl_auth_logout.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl auth logout"
 displayName: "auth logout"
 slug: uptimectl_auth_logout

--- a/docs/references/uptimectl_config.md
+++ b/docs/references/uptimectl_config.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config"
 displayName: "config"
 slug: uptimectl_config

--- a/docs/references/uptimectl_config_current-context.md
+++ b/docs/references/uptimectl_config_current-context.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config current-context"
 displayName: "config current-context"
 slug: uptimectl_config_current-context

--- a/docs/references/uptimectl_config_get-contexts.md
+++ b/docs/references/uptimectl_config_get-contexts.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config get-contexts"
 displayName: "config get-contexts"
 slug: uptimectl_config_get-contexts

--- a/docs/references/uptimectl_config_use-context.md
+++ b/docs/references/uptimectl_config_use-context.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config use-context"
 displayName: "config use-context"
 slug: uptimectl_config_use-context

--- a/docs/references/uptimectl_config_use-organisation.md
+++ b/docs/references/uptimectl_config_use-organisation.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config use-organisation"
 displayName: "config use-organisation"
 slug: uptimectl_config_use-organisation

--- a/docs/references/uptimectl_config_view.md
+++ b/docs/references/uptimectl_config_view.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl config view"
 displayName: "config view"
 slug: uptimectl_config_view

--- a/docs/references/uptimectl_incident.md
+++ b/docs/references/uptimectl_incident.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl incident"
 displayName: "incident"
 slug: uptimectl_incident

--- a/docs/references/uptimectl_incident_acknowledge.md
+++ b/docs/references/uptimectl_incident_acknowledge.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl incident acknowledge"
 displayName: "incident acknowledge"
 slug: uptimectl_incident_acknowledge

--- a/docs/references/uptimectl_incident_delete.md
+++ b/docs/references/uptimectl_incident_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl incident delete"
 displayName: "incident delete"
 slug: uptimectl_incident_delete

--- a/docs/references/uptimectl_incident_list.md
+++ b/docs/references/uptimectl_incident_list.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl incident list"
 displayName: "incident list"
 slug: uptimectl_incident_list

--- a/docs/references/uptimectl_incident_resolve.md
+++ b/docs/references/uptimectl_incident_resolve.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl incident resolve"
 displayName: "incident resolve"
 slug: uptimectl_incident_resolve
@@ -20,8 +20,8 @@ uptimectl incident resolve [flags]
 ### Options
 
 ```
-      --acknowledged-by string   User e-mail or a custom identifier of the entity that acknowledged the incident (default "uptimectl")
-  -h, --help                     help for resolve
+  -h, --help                 help for resolve
+      --resolved-by string   User e-mail or a custom identifier of the entity that resolved the incident (default "uptimectl")
 ```
 
 ### SEE ALSO

--- a/docs/references/uptimectl_monitor-groups.md
+++ b/docs/references/uptimectl_monitor-groups.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitor-groups"
 displayName: "monitor-groups"
 slug: uptimectl_monitor-groups

--- a/docs/references/uptimectl_monitor-groups_create.md
+++ b/docs/references/uptimectl_monitor-groups_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitor-groups create"
 displayName: "monitor-groups create"
 slug: uptimectl_monitor-groups_create

--- a/docs/references/uptimectl_monitor-groups_delete.md
+++ b/docs/references/uptimectl_monitor-groups_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitor-groups delete"
 displayName: "monitor-groups delete"
 slug: uptimectl_monitor-groups_delete

--- a/docs/references/uptimectl_monitor-groups_get.md
+++ b/docs/references/uptimectl_monitor-groups_get.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitor-groups get"
 displayName: "monitor-groups get"
 slug: uptimectl_monitor-groups_get

--- a/docs/references/uptimectl_monitors.md
+++ b/docs/references/uptimectl_monitors.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitors"
 displayName: "monitors"
 slug: uptimectl_monitors
 url: /docs/references/uptimectl/uptimectl_monitors/
 description: ""
 lead: ""
-weight: 738
+weight: 736
 toc: true
 ---
 ## uptimectl monitors
@@ -25,4 +25,6 @@ Manage monitors
 * [uptimectl monitors create](/docs/references/uptimectl/uptimectl_monitors_create/)	 - create a monitor
 * [uptimectl monitors delete](/docs/references/uptimectl/uptimectl_monitors_delete/)	 - delete a monitor
 * [uptimectl monitors get](/docs/references/uptimectl/uptimectl_monitors_get/)	 - Get a list of monitors
+* [uptimectl monitors pause](/docs/references/uptimectl/uptimectl_monitors_pause/)	 - Pause monitors by ID
+* [uptimectl monitors unpause](/docs/references/uptimectl/uptimectl_monitors_unpause/)	 - Unpause monitors by ID
 

--- a/docs/references/uptimectl_monitors_create.md
+++ b/docs/references/uptimectl_monitors_create.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitors create"
 displayName: "monitors create"
 slug: uptimectl_monitors_create

--- a/docs/references/uptimectl_monitors_delete.md
+++ b/docs/references/uptimectl_monitors_delete.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitors delete"
 displayName: "monitors delete"
 slug: uptimectl_monitors_delete

--- a/docs/references/uptimectl_monitors_get.md
+++ b/docs/references/uptimectl_monitors_get.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl monitors get"
 displayName: "monitors get"
 slug: uptimectl_monitors_get

--- a/docs/references/uptimectl_monitors_pause.md
+++ b/docs/references/uptimectl_monitors_pause.md
@@ -1,0 +1,39 @@
+---
+date: 2023-12-04T20:57:39+01:00
+title: "uptimectl monitors pause"
+displayName: "monitors pause"
+slug: uptimectl_monitors_pause
+url: /docs/references/uptimectl/uptimectl_monitors_pause/
+description: ""
+lead: ""
+weight: 738
+toc: true
+---
+## uptimectl monitors pause
+
+Pause monitors by ID
+
+```
+uptimectl monitors pause [flags]
+```
+
+### Examples
+
+```
+# Pause a monitor
+uptimectl monitors pause 1234567
+
+# Pause multiple monitors
+uptimectl monitors pause 1234567 2345678 3456789
+```
+
+### Options
+
+```
+  -h, --help   help for pause
+```
+
+### SEE ALSO
+
+* [uptimectl monitors](/docs/references/uptimectl/uptimectl_monitors/)	 - Manage monitors
+

--- a/docs/references/uptimectl_monitors_unpause.md
+++ b/docs/references/uptimectl_monitors_unpause.md
@@ -1,0 +1,39 @@
+---
+date: 2023-12-04T20:57:39+01:00
+title: "uptimectl monitors unpause"
+displayName: "monitors unpause"
+slug: uptimectl_monitors_unpause
+url: /docs/references/uptimectl/uptimectl_monitors_unpause/
+description: ""
+lead: ""
+weight: 737
+toc: true
+---
+## uptimectl monitors unpause
+
+Unpause monitors by ID
+
+```
+uptimectl monitors unpause [flags]
+```
+
+### Examples
+
+```
+# Unpause a monitor
+uptimectl monitors unpause 1234567
+
+# Unpause multiple monitors
+uptimectl monitors unpause 1234567 2345678 3456789
+```
+
+### Options
+
+```
+  -h, --help   help for unpause
+```
+
+### SEE ALSO
+
+* [uptimectl monitors](/docs/references/uptimectl/uptimectl_monitors/)	 - Manage monitors
+

--- a/docs/references/uptimectl_on-call.md
+++ b/docs/references/uptimectl_on-call.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl on-call"
 displayName: "on-call"
 slug: uptimectl_on-call
 url: /docs/references/uptimectl/uptimectl_on-call/
 description: ""
 lead: ""
-weight: 737
+weight: 735
 toc: true
 ---
 ## uptimectl on-call

--- a/docs/references/uptimectl_status-pages.md
+++ b/docs/references/uptimectl_status-pages.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl status-pages"
 displayName: "status-pages"
 slug: uptimectl_status-pages
 url: /docs/references/uptimectl/uptimectl_status-pages/
 description: ""
 lead: ""
-weight: 732
+weight: 730
 toc: true
 ---
 ## uptimectl status-pages

--- a/docs/references/uptimectl_status-pages_create.md
+++ b/docs/references/uptimectl_status-pages_create.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl status-pages create"
 displayName: "status-pages create"
 slug: uptimectl_status-pages_create
 url: /docs/references/uptimectl/uptimectl_status-pages_create/
 description: ""
 lead: ""
-weight: 736
+weight: 734
 toc: true
 ---
 ## uptimectl status-pages create

--- a/docs/references/uptimectl_status-pages_delete.md
+++ b/docs/references/uptimectl_status-pages_delete.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl status-pages delete"
 displayName: "status-pages delete"
 slug: uptimectl_status-pages_delete
 url: /docs/references/uptimectl/uptimectl_status-pages_delete/
 description: ""
 lead: ""
-weight: 735
+weight: 733
 toc: true
 ---
 ## uptimectl status-pages delete

--- a/docs/references/uptimectl_status-pages_get.md
+++ b/docs/references/uptimectl_status-pages_get.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl status-pages get"
 displayName: "status-pages get"
 slug: uptimectl_status-pages_get
 url: /docs/references/uptimectl/uptimectl_status-pages_get/
 description: ""
 lead: ""
-weight: 734
+weight: 732
 toc: true
 ---
 ## uptimectl status-pages get

--- a/docs/references/uptimectl_status-pages_resources.md
+++ b/docs/references/uptimectl_status-pages_resources.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl status-pages resources"
 displayName: "status-pages resources"
 slug: uptimectl_status-pages_resources
 url: /docs/references/uptimectl/uptimectl_status-pages_resources/
 description: ""
 lead: ""
-weight: 733
+weight: 731
 toc: true
 ---
 ## uptimectl status-pages resources

--- a/docs/references/uptimectl_version.md
+++ b/docs/references/uptimectl_version.md
@@ -1,12 +1,12 @@
 ---
-date: 2023-11-17T13:00:50-05:00
+date: 2023-12-04T20:57:39+01:00
 title: "uptimectl version"
 displayName: "version"
 slug: uptimectl_version
 url: /docs/references/uptimectl/uptimectl_version/
 description: ""
 lead: ""
-weight: 731
+weight: 729
 toc: true
 ---
 ## uptimectl version

--- a/pkg/betteruptime/monitors.go
+++ b/pkg/betteruptime/monitors.go
@@ -102,10 +102,64 @@ func (c *client) ListMonitors() ([]Monitor, error) {
 	return monitors, nil
 }
 
+func (c *client) PauseMonitor(id string) error {
+	result := GetMonitorResponse{}
+
+	endpoint := fmt.Sprintf("%s/%s/%s", contextmanager.APIEndpoint(), monitorEndpoint, id)
+
+	updateRequest := UpdateMonitorRequest{
+		Paused: true,
+	}
+
+	resp, err := c.rest.R().
+		SetResult(&result).
+		SetBody(updateRequest).
+		Patch(endpoint)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("incorrect status response")
+	}
+
+	fmt.Printf("monitor \"%s\" paused\n", id)
+
+	return nil
+}
+
+func (c *client) UnpauseMonitor(id string) error {
+	result := GetMonitorResponse{}
+
+	endpoint := fmt.Sprintf("%s/%s/%s", contextmanager.APIEndpoint(), monitorEndpoint, id)
+
+	updateRequest := UpdateMonitorRequest{
+		Paused: false,
+	}
+
+	resp, err := c.rest.R().
+		SetResult(&result).
+		SetBody(updateRequest).
+		Patch(endpoint)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("incorrect status response")
+	}
+
+	fmt.Printf("monitor \"%s\" unpaused\n", id)
+
+	return nil
+}
+
 type CreateMonitorRequest struct {
 	Name      string `json:"name"`
 	Paused    bool   `json:"paused"`
 	SortIndex *int   `json:"sort_index"`
+}
+
+type UpdateMonitorRequest struct {
+	Paused bool `json:"paused"`
 }
 
 type ListMonitorResponse struct {


### PR DESCRIPTION
Add a subcommand under the `monitors` command to pause and unpause monitors using their ID.

Example pausing multiple monitors:
`uptimectl monitors pause 1234567 2345678 3456789`

